### PR TITLE
Move dependencies to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,17 +10,14 @@
   ],
   "main": "dist/blocto-sdk.js",
   "browser": "dist/blocto-sdk.umd.js",
-  "dependencies": {
-    "@babel/plugin-transform-runtime": "^7.14.5",
-    "@babel/runtime": "^7.14.6",
-    "dotenv": "^10.0.0",
-    "ethereumjs-vm": "^4.2.0"
-  },
   "devDependencies": {
     "@babel/core": "^7.14.0",
+    "@babel/plugin-transform-runtime": "^7.14.5",
     "@babel/preset-env": "^7.14.1",
+    "@babel/runtime": "^7.14.6",
     "@rollup/plugin-alias": "^3.1.2",
     "@rollup/plugin-babel": "^5.3.0",
+    "dotenv": "^10.0.0",
     "rimraf": "^3.0.2",
     "rollup": "^2.47.0",
     "rollup-plugin-commonjs": "^10.1.0",


### PR DESCRIPTION
To spare projects using Blocto SDK some node_modules tree size