### PR TITLE
consolidate and export config interfaces

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -2,6 +2,10 @@ type Mapping = {
   [key in number | string]: string;
 };
 
+export interface BaseConfig {
+  appId: string | null;
+}
+
 /* eth series constants begin */
 
 export const ETH_CHAIN_ID_RPC_MAPPING: Mapping = {

--- a/src/main.ts
+++ b/src/main.ts
@@ -11,7 +11,7 @@ export interface BloctoSDKConfig extends BaseConfig {
   solana: Omit<SolanaProviderConfig, 'appId'>;
 }
 
-class BloctoSDK {
+export default class BloctoSDK {
   ethereum: EthereumProvider;
   solana: SolanaProvider;
 
@@ -20,5 +20,3 @@ class BloctoSDK {
     this.solana = new SolanaProvider({ ...solana, appId });
   }
 }
-
-export default BloctoSDK;

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,20 +1,16 @@
-import EthereumProvider from './providers/ethereum';
-import SolanaProvider from './providers/solana';
+import { BaseConfig } from './constants';
+import EthereumProvider, { EthereumProviderConfig } from './providers/ethereum';
+import SolanaProvider, { SolanaProviderConfig } from './providers/solana';
 
 // eslint-disable-next-line
 import dotenv from 'dotenv';
 dotenv.config();
-interface BloctoSDKConfig {
-  appId: string | null;
-  ethereum: {
-    chainId: string | number;
-    rpc?: string;
-    server?: string;
-  };
-  solana: {
-    net: string;
-  }
+
+export interface BloctoSDKConfig extends BaseConfig {
+  ethereum: Omit<EthereumProviderConfig, 'appId'>;
+  solana: Omit<SolanaProviderConfig, 'appId'>;
 }
+
 class BloctoSDK {
   ethereum: EthereumProvider;
   solana: SolanaProvider;

--- a/src/providers/ethereum.ts
+++ b/src/providers/ethereum.ts
@@ -8,6 +8,7 @@ import {
   KEY_SESSION,
 } from '../lib/localStorage';
 import {
+  BaseConfig,
   ETH_CHAIN_ID_RPC_MAPPING,
   ETH_CHAIN_ID_CHAIN_MAPPING,
   ETH_CHAIN_ID_NET_MAPPING,
@@ -15,14 +16,13 @@ import {
   LOGIN_PERSISTING_TIME,
 } from '../constants';
 
-interface EthereumProviderConfig {
+export interface EthereumProviderConfig extends BaseConfig {
   chainId: string | number | null;
   rpc?: string;
   server?: string;
-  appId: string | null;
 }
 
-interface EIP1193RequestPayload {
+export interface EIP1193RequestPayload {
   id?: number;
   jsonrpc?: string;
   method: string;

--- a/src/providers/ethereum.ts
+++ b/src/providers/ethereum.ts
@@ -29,7 +29,7 @@ export interface EIP1193RequestPayload {
   params?: Array<any>;
 }
 
-class EthereumProvider extends BloctoProvider {
+export default class EthereumProvider extends BloctoProvider {
   code: string | null = null;
   chainId: string | number;
   networkId: string | number;
@@ -373,5 +373,3 @@ class EthereumProvider extends BloctoProvider {
     });
   }
 }
-
-export default EthereumProvider;

--- a/src/providers/solana.ts
+++ b/src/providers/solana.ts
@@ -22,7 +22,7 @@ export interface SolanaRequest {
   params?: Object;
 }
 
-class SolanaProvider extends BloctoProvider {
+export default class SolanaProvider extends BloctoProvider {
   code: string | null = null;
   net: string;
   rpc: string;
@@ -264,5 +264,3 @@ class SolanaProvider extends BloctoProvider {
     });
   }
 }
-
-export default SolanaProvider;

--- a/src/providers/solana.ts
+++ b/src/providers/solana.ts
@@ -3,6 +3,7 @@ import { createFrame, attachFrame, detatchFrame } from '../lib/frame';
 import addSelfRemovableHandler from '../lib/addSelfRemovableHandler';
 import BloctoProvider from './blocto';
 import {
+  BaseConfig,
   SOL_NET_SERVER_MAPPING,
   SOL_NET,
 } from '../constants';
@@ -11,13 +12,12 @@ import { Buffer } from 'buffer';
 import { Transaction, Message, TransactionSignature, TransactionInstruction, PublicKey } from '@solana/web3.js';
 import bs58 from 'bs58';
 
-interface SolanaProviderConfig {
+export interface SolanaProviderConfig extends BaseConfig {
   net: string | null;
   server?: string;
-  appId: string | null;
 }
 
-interface SolanaRequest {
+export interface SolanaRequest {
   method: string;
   params?: Object;
 }


### PR DESCRIPTION
This PR consolidates the types used for the configuration interfaces for the SDK and providers since they all require `appId`, and exports these types so applications building with the Blocto SDK can more easily use them.