### PR TITLE
fix: prevent window access in SSR

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -88,3 +88,5 @@ export const EIP1193_EVENTS: Array<string> = ['connect', 'disconnect', 'message'
 
 // Preserve login for 1 day
 export const LOGIN_PERSISTING_TIME = 86400 * 1000;
+
+export const CAN_USE_WINDOW = typeof window !== 'undefined'

--- a/src/lib/localStorage/localStorage.ts
+++ b/src/lib/localStorage/localStorage.ts
@@ -1,7 +1,11 @@
 import MemoryStorage from './memoryStorage';
 import * as keys from './constants';
+import { CAN_USE_WINDOW } from '../../constants';
 
 const isSupported = () => {
+  if (!CAN_USE_WINDOW) {
+    return false;
+  }
   try {
     window.localStorage.setItem('local_storage_supported', '1');
     const result = window.localStorage.getItem('local_storage_supported');

--- a/src/lib/localStorage/memoryStorage.ts
+++ b/src/lib/localStorage/memoryStorage.ts
@@ -1,3 +1,5 @@
+import { CAN_USE_WINDOW } from "../../constants";
+
 class MemoryStorage {
     storage = {};
 
@@ -14,7 +16,11 @@ class MemoryStorage {
     }
 }
 
-window.memoryStorage = window.memoryStorage || new MemoryStorage();
+const memoryStorage = CAN_USE_WINDOW ? window.memoryStorage : new MemoryStorage();
 
-export default window.memoryStorage;
+if (CAN_USE_WINDOW) {
+  window.memoryStorage = memoryStorage;
+}
+
+export default memoryStorage;
 export { MemoryStorage };


### PR DESCRIPTION
This PR fixes #14. When developing NextJS apps it is a default to have a server-render pass (even when building the static pages). This is breaking due to the top-level window accesses in this package. Given that there is the `MemoryStorage` that can be used for back-up when `localStorage` is not available, we can just use that same logic in the server-side render. Once the client loads `CAN_USE_WINDOW` will become truthy and `window` can be accessed as normal.