### PR TITLE
Improvements

### DIFF
--- a/src/providers/blocto.ts
+++ b/src/providers/blocto.ts
@@ -1,6 +1,6 @@
 // The root class for all providers
 
-import { EIP1193Provider } from 'eip1193-provider';
+import { EIP1193Provider, RequestArguments } from 'eip1193-provider';
 
 import { EIP1193_EVENTS } from '../constants';
 import { KEY_SESSION } from '../lib/localStorage/constants';
@@ -26,7 +26,7 @@ class BloctoProvider implements EIP1193Provider {
 
   // implement by children
   // eslint-disable-next-line
-  async request(payload: any) {}
+  async request(payload: RequestArguments) {}
 
   on(event: string, listener: (arg: any) => void): void {
     if (!EIP1193_EVENTS.includes(event)) return;

--- a/src/providers/ethereum.ts
+++ b/src/providers/ethereum.ts
@@ -197,6 +197,12 @@ export default class EthereumProvider extends BloctoProvider implements Ethereum
         default:
           response = await this.handleReadRequests(payload);
       }
+
+      if (response && !response.result && response.error) {
+        const errorMessage = response.error.message ? response.error.message : 'Request failed';
+        throw new Error(errorMessage);
+      }
+
       if (response) return response.result;
       return result;
     } catch (error) {

--- a/src/providers/ethereum.ts
+++ b/src/providers/ethereum.ts
@@ -274,7 +274,7 @@ export default class EthereumProvider extends BloctoProvider implements Ethereum
           if (e.data.type === 'FCL::CHALLENGE::CANCEL') {
             removeListener();
             detatchFrame(loginFrame);
-            reject();
+            reject(new Error('User declined the login request'));
           }
         }
       });
@@ -346,7 +346,7 @@ export default class EthereumProvider extends BloctoProvider implements Ethereum
           if (e.data.status === 'DECLINED') {
             removeEventListener();
             detatchFrame(signFrame);
-            reject();
+            reject(new Error('User declined the signing request'));
           }
         }
       })
@@ -384,7 +384,7 @@ export default class EthereumProvider extends BloctoProvider implements Ethereum
           if (e.data.status === 'DECLINED') {
             removeEventListener();
             detatchFrame(authzFrame);
-            reject();
+            reject(new Error('User declined to send the transaction'));
           }
         }
       })

--- a/src/providers/ethereum.ts
+++ b/src/providers/ethereum.ts
@@ -1,7 +1,9 @@
 import invariant from 'invariant';
+import { ProviderAccounts } from 'eip1193-provider';
 import BloctoProvider from './blocto';
 import Session from '../lib/session.d';
-import { EthereumProviderConfig, EthereumProviderInterface } from './types/ethereum.d'; import { createFrame, attachFrame, detatchFrame } from '../lib/frame';
+import { EIP1193RequestPayload, EthereumProviderConfig, EthereumProviderInterface } from './types/ethereum.d';
+import { createFrame, attachFrame, detatchFrame } from '../lib/frame';
 import addSelfRemovableHandler from '../lib/addSelfRemovableHandler';
 import {
   getItemWithExpiry,
@@ -15,13 +17,6 @@ import {
   ETH_CHAIN_ID_SERVER_MAPPING,
   LOGIN_PERSISTING_TIME,
 } from '../constants';
-
-export interface EIP1193RequestPayload {
-  id?: number;
-  jsonrpc?: string;
-  method: string;
-  params?: Array<any>;
-}
 
 export default class EthereumProvider extends BloctoProvider implements EthereumProviderInterface {
   chainId: string | number;
@@ -213,7 +208,7 @@ export default class EthereumProvider extends BloctoProvider implements Ethereum
 
   // eip-1102 alias
   // DEPRECATED API: https://github.com/ethereum/EIPs/blob/master/EIPS/eip-1102.md
-  async enable() {
+  async enable(): Promise<ProviderAccounts> {
     const existedSDK = (window as any).ethereum;
     if (existedSDK && existedSDK.isBlocto) {
       if (parseInt(existedSDK.chainId, 16) !== this.chainId) {

--- a/src/providers/solana.ts
+++ b/src/providers/solana.ts
@@ -148,7 +148,7 @@ export default class SolanaProvider extends BloctoProvider implements SolanaProv
           if (e.data.type === 'FCL::CHALLENGE::CANCEL') {
             removeListener();
             detatchFrame(loginFrame);
-            reject();
+            reject(new Error('User declined the login request'));
           }
         }
       });
@@ -324,7 +324,7 @@ export default class SolanaProvider extends BloctoProvider implements SolanaProv
           if (e.data.status === 'DECLINED') {
             removeEventListener();
             detatchFrame(authzFrame);
-            reject();
+            reject(new Error('User declined to send the transaction'));
           }
         }
       })

--- a/src/providers/solana.ts
+++ b/src/providers/solana.ts
@@ -82,6 +82,12 @@ export default class SolanaProvider extends BloctoProvider implements SolanaProv
         default:
           response = await this.handleReadRequests(payload);
       }
+
+      if (response && !response.result && response.error) {
+        const errorMessage = response.error.message ? response.error.message : 'Request failed';
+        throw new Error(errorMessage);
+      }
+
       if (response) return response.result;
       return result;
     } catch (error) {

--- a/src/providers/solana.ts
+++ b/src/providers/solana.ts
@@ -1,5 +1,6 @@
 import invariant from 'invariant';
 import { Buffer } from 'buffer';
+import { RequestArguments } from 'eip1193-provider';
 // @todo: in the long run we want to remove the dependency of solana web3
 import { Transaction, Message, TransactionSignature, TransactionInstruction, PublicKey, Connection } from '@solana/web3.js';
 import bs58 from 'bs58';
@@ -19,10 +20,6 @@ import {
   LOGIN_PERSISTING_TIME,
 } from '../constants';
 
-export interface SolanaRequest {
-  method: string;
-  params?: any;
-}
 export default class SolanaProvider extends BloctoProvider implements SolanaProviderInterface {
   net: string;
   rpc: string;
@@ -52,7 +49,7 @@ export default class SolanaProvider extends BloctoProvider implements SolanaProv
     this.accounts = sessionAccount ? [sessionAccount] : [];
   }
 
-  async request(payload: SolanaRequest) {
+  async request(payload: RequestArguments) {
     if (!this.connected) {
       await this.connect();
     }
@@ -171,7 +168,7 @@ export default class SolanaProvider extends BloctoProvider implements SolanaProv
     return accounts;
   }
 
-  async handleReadRequests(payload: SolanaRequest): Promise<any> {
+  async handleReadRequests(payload: RequestArguments): Promise<any> {
     return fetch(this.rpc, {
       method: 'POST',
       headers: {
@@ -275,7 +272,7 @@ export default class SolanaProvider extends BloctoProvider implements SolanaProv
     }, {} as { [key: string]: string });
   }
 
-  async handleConvertTransaction(payload: SolanaRequest) {
+  async handleConvertTransaction(payload: RequestArguments) {
     return fetch(`${this.server}/api/solana/convertToWalletTx?code=${this.code}`, {
       method: 'POST',
       headers: {
@@ -288,7 +285,7 @@ export default class SolanaProvider extends BloctoProvider implements SolanaProv
     }).then(response => responseSessionGuard(response, this));
   }
 
-  async handleSignAndSendTransaction(payload: SolanaRequest): Promise<string> {
+  async handleSignAndSendTransaction(payload: RequestArguments): Promise<string> {
     const { authorizationId } = await fetch(`${this.server}/api/solana/authz?code=${this.code}`, {
       method: 'POST',
       headers: {

--- a/src/providers/solana.ts
+++ b/src/providers/solana.ts
@@ -67,6 +67,18 @@ export default class SolanaProvider extends BloctoProvider implements SolanaProv
         case 'getAccounts':
           result = this.accounts.length ? this.accounts : await this.fetchAccounts();
           break;
+        case 'getAccountInfo': {
+          // Format the data as the same format returning from Connection.getAccountInfo from @solana/web3.js
+          // ref: https://solana-labs.github.io/solana-web3.js/classes/Connection.html#getAccountInfo
+          const accountInfo = await this.handleReadRequests(payload);
+          const [bufferData, encoding] = accountInfo.result.value.data;
+          result = {
+            ...accountInfo.result.value,
+            data: Buffer.from(bufferData, encoding),
+            owner: new PublicKey(accountInfo.result.value.owner),
+          };
+          break;
+        }
         // custom JSON-RPC method
         case 'convertToProgramWalletTransaction':
           result = await this.handleConvertTransaction(payload);

--- a/src/providers/types/ethereum.d.ts
+++ b/src/providers/types/ethereum.d.ts
@@ -1,3 +1,4 @@
+import { IEthereumProvider } from 'eip1193-provider';
 import { BaseConfig } from '../../constants';
 import BloctoProviderInterface from './blocto.d';
 
@@ -7,7 +8,14 @@ export declare interface EthereumProviderConfig extends BaseConfig {
   server?: string;
 }
 
-export declare interface EthereumProviderInterface extends BloctoProviderInterface {
+export interface EIP1193RequestPayload {
+  id?: number;
+  jsonrpc?: string;
+  method: string;
+  params?: Array<any>;
+}
+
+export declare interface EthereumProviderInterface extends BloctoProviderInterface, IEthereumProvider {
   chainId: string | number;
   networkId: string | number;
   chain: string;
@@ -15,5 +23,6 @@ export declare interface EthereumProviderInterface extends BloctoProviderInterfa
   rpc: string;
   server: string;
   accounts: Array<string>;
+  request(args: EIP1193RequestPayload): Promise<any>;
 }
 

--- a/src/providers/types/solana.d.ts
+++ b/src/providers/types/solana.d.ts
@@ -1,4 +1,5 @@
 import { Connection, Transaction } from '@solana/web3.js';
+import { RequestArguments } from 'eip1193-provider';
 import { BaseConfig } from '../../constants';
 import BloctoProviderInterface from './blocto.d';
 
@@ -16,7 +17,7 @@ export declare interface SolanaProviderInterface extends BloctoProviderInterface
 
   connect(): Promise<void>;
   disconnect(): Promise<void>;
-  request(params: { method: string }): Promise<any>;
+  request(params: RequestArguments): Promise<any>;
 
   signAndSendTransaction(transaction: Transaction, connection?: Connection): Promise<string>;
   convertToProgramWalletTransaction(transaction: Transaction): Promise<Transaction>;


### PR DESCRIPTION
- Update the types for mapping the right types in typescript(d9f22bb98a6ca5beefbc3c3b059a134570c59de8)
- Throw error messages for the failed requests and the unsupported RPC method(2faa0e76d8b656bcbbc2cfddec756dba8d3ab0cb)
   (ref: https://app.asana.com/0/1201211730179732/1201491509849683/f)
- Reject the promise with a proper error message(a65a5ea86d361693cd0cf6d7ff6271c49b7e1a74)
- Format the data for `getAccountInfo` to match the result format of `Connection.getAccountInfo` from `@solana/web3.js`(9853aba06255680700c3ecf28705b5bf5b8d9f43)

<br/>

The issue of the expired error when requesting with another SDK instance in the different chain seems to be fixed with the commit in https://github.com/portto/wallet-webapp/commit/d28ae1fb214bba6d9c64fd427be55c035e5681de
So we do nothing here in this PR but I guess we can mark the task in Asana as completed now 🙂
(ref: https://app.asana.com/0/1201211730179732/1201504752520183/f)