### PR TITLE
Feat: Get account data from localStorage at page start on Aptos.

### DIFF
--- a/src/lib/session.d.ts
+++ b/src/lib/session.d.ts
@@ -4,6 +4,8 @@ interface Session {
   address?: {
     [key: string]: string
   };
+  chainId?: number;
+  appId?: string;
 }
 
 export default Session;

--- a/src/providers/aptos.ts
+++ b/src/providers/aptos.ts
@@ -40,6 +40,8 @@ export default class AptosProvider extends BloctoProvider implements AptosProvid
   constructor({ chainId, server, appId }: AptosProviderConfig) {
     super();
     invariant(chainId, "'chainId' is required");
+    invariant(appId, 'It is necessary to interact with Blocto wallet via your app id.');
+
     this.chainId = chainId;
     this.networkName = APT_CHAIN_ID_NAME_MAPPING[chainId];
     this.api = APT_CHAIN_ID_RPC_MAPPING[chainId];
@@ -228,7 +230,7 @@ export default class AptosProvider extends BloctoProvider implements AptosProvid
       }
 
       const location = encodeURIComponent(window.location.origin);
-      const loginFrame = createFrame(`${this.server}/authn?l6n=${location}&chain=aptos`);
+      const loginFrame = createFrame(`${this.server}/authn?l6n=${location}&chain=aptos&appId=${this.appId}`);
 
       attachFrame(loginFrame);
 

--- a/src/providers/types/aptos.d.ts
+++ b/src/providers/types/aptos.d.ts
@@ -29,5 +29,6 @@ export declare interface AptosProviderInterface extends BloctoProviderInterface 
   signTransaction(transaction: any): Promise<SubmitTransactionRequest>;
   signMessage(payload: SignMessagePayload): Promise<SignMessageResponse>;
   disconnect(): Promise<void>;
+  address?: string
 }
 


### PR DESCRIPTION
## Summary 
- get account data like publicKey and address from localStorage if they're exist at the beginning of page rendering.