### PR TITLE
fix: beta-release script

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -1,5 +1,5 @@
 {
-  "mode": "pre",
+  "mode": "exit",
   "tag": "beta",
   "initialVersions": {
     "@blocto/aptos-wallet-adapter-plugin": "0.1.4",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "dev": "turbo run dev",
     "lint": "turbo run lint",
     "format": "prettier --write \"**/*.{ts,tsx,md}\"",
-    "beta-release": "turbo run build && changeset pre enter beta && changeset version && changeset publish",
+    "beta-release": "turbo run build && changeset pre enter beta && changeset version && changeset publish && changeset pre exit",
     "release": "turbo run build && changeset version && changeset publish"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary
Now can use `yarn beta-release` and `yarn release` to auto version and publish to npm. 
This command should only run by maintainer.