### PR TITLE
fix: remove outdated invariant package

### DIFF
--- a/adapters/blocto-connector/package.json
+++ b/adapters/blocto-connector/package.json
@@ -41,8 +41,7 @@
   "dependencies": {
     "@blocto/sdk": "^0.4.4",
     "@web3-react/abstract-connector": "^6.0.7",
-    "@web3-react/types": "^6.0.7",
-    "tiny-invariant": "^1.1.0"
+    "@web3-react/types": "^6.0.7"
   },
   "devDependencies": {
     "tsdx": "^0.14.1"

--- a/adapters/blocto-connector/src/index.ts
+++ b/adapters/blocto-connector/src/index.ts
@@ -1,6 +1,5 @@
 import { ConnectorUpdate } from '@web3-react/types';
 import { AbstractConnector } from '@web3-react/abstract-connector';
-import invariant from 'tiny-invariant';
 import BloctoSDK from '@blocto/sdk';
 
 interface BloctoConnectorArguments {
@@ -8,29 +7,12 @@ interface BloctoConnectorArguments {
   rpc: string;
 }
 
-const chainIdToNetwork: { [network: number]: string } = {
-  1: 'mainnet',
-  3: 'ropsten',
-  4: 'rinkeby',
-  42: 'kovan',
-  56: 'bsc', // BSC Mainnet
-  97: 'chapel', // BSC Testnet
-  137: 'polygon', // Polygon Mainnet
-  80001: 'mumbai', // Polygon Testnet
-  43114: 'avalanche', // Avalanche Mainnet
-  43113: 'fuji', // Avalanche Testnet
-};
-
 export class BloctoConnector extends AbstractConnector {
   private readonly chainId: number;
   private readonly rpc: string;
   public blocto: any;
 
   constructor({ chainId, rpc }: BloctoConnectorArguments) {
-    invariant(
-      Object.keys(chainIdToNetwork).includes(chainId.toString()),
-      `Unsupported chainId ${chainId}`
-    );
     super({ supportedChainIds: [chainId] });
     this.chainId = chainId;
     this.rpc = rpc;

--- a/adapters/blocto-connector/tsconfig.json
+++ b/adapters/blocto-connector/tsconfig.json
@@ -1,5 +1,4 @@
 {
-  "extends": "../../tsconfig.json",
   "include": ["src"],
   "compilerOptions": {
     "rootDir": "./",

--- a/packages/blocto-sdk/package.json
+++ b/packages/blocto-sdk/package.json
@@ -62,7 +62,6 @@
     "rollup-plugin-terser": "^7.0.2",
     "rollup-plugin-typescript": "^1.0.1",
     "rollup-plugin-visualizer": "^5.5.4",
-    "tiny-invariant": "^1.3.1",
     "tslib": "^2.3.0",
     "typescript": "~4.8.0",
     "yarn-run-all": "^3.1.1"

--- a/packages/blocto-sdk/src/lib/invariant.ts
+++ b/packages/blocto-sdk/src/lib/invariant.ts
@@ -1,0 +1,7 @@
+// instead invariant from package, since all error will throw on production
+function invariant(condition: any, format: string): void {
+  if (!condition) {
+    throw new Error(format);
+  }
+}
+export default invariant;

--- a/packages/blocto-sdk/src/providers/aptos.ts
+++ b/packages/blocto-sdk/src/providers/aptos.ts
@@ -1,4 +1,4 @@
-import invariant from 'tiny-invariant';
+import invariant from '../lib/invariant';
 import type {
   SignMessagePayload,
   SignMessageResponse,

--- a/packages/blocto-sdk/src/providers/ethereum.ts
+++ b/packages/blocto-sdk/src/providers/ethereum.ts
@@ -1,4 +1,4 @@
-import invariant from 'tiny-invariant';
+import invariant from '../lib/invariant';
 import { ProviderAccounts } from 'eip1193-provider';
 import BloctoProvider from './blocto';
 import Session from '../lib/session.d';
@@ -38,7 +38,10 @@ interface SwitchableNetwork {
   };
 }
 
-function parseChainId(chainId: string | number): number {
+function parseChainId(chainId: string | number | null): number {
+  if (!chainId) {
+    return 1;
+  }
   if (typeof chainId === 'number') {
     return chainId;
   } else if (chainId.startsWith('0x')) {
@@ -354,7 +357,7 @@ export default class EthereumProvider
 
           this.server = this.switchableNetwork[this.chainId].wallet_web_url;
           this.accounts = await this.fetchAccounts();
-          this.eventListeners.chainChanged.forEach((listener) => 
+          this.eventListeners.chainChanged.forEach((listener) =>
             listener(this.chainId)
           );
           result = null;

--- a/packages/blocto-sdk/src/providers/solana.ts
+++ b/packages/blocto-sdk/src/providers/solana.ts
@@ -1,4 +1,4 @@
-import invariant from 'tiny-invariant';
+import invariant from '../lib/invariant';
 import { Buffer } from 'buffer';
 import { RequestArguments } from 'eip1193-provider';
 // @todo: in the long run we want to remove the dependency of solana web3

--- a/yarn.lock
+++ b/yarn.lock
@@ -11964,11 +11964,6 @@ tiny-glob@^0.2.6, tiny-glob@^0.2.9:
     globalyzer "0.1.0"
     globrex "^0.1.2"
 
-tiny-invariant@^1.1.0, tiny-invariant@^1.3.1:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/tiny-invariant/-/tiny-invariant-1.3.1.tgz#8560808c916ef02ecfd55e66090df23a4b7aa642"
-  integrity sha512-AD5ih2NlSssTCwsMznbvwMZpJ1cbhkGd2uueNxzv2jDlEeZdU04JQfRnggJQ8DrcVBGjAsCKwFBbDlVNtEMlzw==
-
 tmp@^0.0.33:
   version "0.0.33"
   resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.0.33.tgz#6d34335889768d21b2bcda0aa277ced3b1bfadf9"


### PR DESCRIPTION
## Summary
Use custom invariant instead from package prevent process undefined error. Plus, since all error will throw on production, no need to determine environment now.