### PR TITLE
feat: EIP-1193 batchTx params support web3 sendTx type

### DIFF
--- a/.changeset/short-mails-enjoy.md
+++ b/.changeset/short-mails-enjoy.md
@@ -1,0 +1,5 @@
+---
+'@blocto/sdk': patch
+---
+
+blocto_batchTransaction support web3 sendTx type

--- a/README.md
+++ b/README.md
@@ -110,5 +110,3 @@ Changesets are designed to stack, so there's no problem with adding multiple. Yo
 
 - You want to release multiple packages with different changelog entries
 - You have made multiple changes to a package that should each be called out separately
-
-

--- a/adapters/rainbowkit-connector/src/index.ts
+++ b/adapters/rainbowkit-connector/src/index.ts
@@ -2,10 +2,7 @@ import BloctoSDK from '@blocto/sdk';
 import type { EthereumProviderInterface } from '@blocto/sdk';
 import { Chain, Wallet } from '@rainbow-me/rainbowkit';
 import { ConnectorNotFoundError } from 'wagmi';
-import {
-  SwitchChainError,
-  UserRejectedRequestError,
-} from "viem";
+import { SwitchChainError, UserRejectedRequestError } from 'viem';
 import { InjectedConnector } from 'wagmi/connectors/injected';
 export interface BloctoWalletOptions {
   chains: Chain[];
@@ -83,7 +80,7 @@ export class BloctoConnector extends InjectedConnector {
     const accounts = await blocto?.ethereum?.request({
       method: 'eth_requestAccounts',
     });
-    if(!accounts?.length) throw new ConnectorNotFoundError()
+    if (!accounts?.length) throw new ConnectorNotFoundError();
     return accounts[0];
   }
   async getChainId(): Promise<number> {
@@ -129,10 +126,10 @@ export class BloctoConnector extends InjectedConnector {
       return chain;
     } catch (error: any) {
       const chain = this.chains.find((x) => x.id === chainId);
-      if (!chain){
+      if (!chain) {
         throw new ConnectorNotFoundError('chain not found');
       }
-      if (this.isUserRejectedRequestError(error)){
+      if (this.isUserRejectedRequestError(error)) {
         throw new UserRejectedRequestError(error);
       }
       throw new SwitchChainError(error);

--- a/packages/blocto-sdk/src/index.d.ts
+++ b/packages/blocto-sdk/src/index.d.ts
@@ -14,9 +14,9 @@ import {
   AptosProviderConfig,
   AptosProviderInterface,
 } from './providers/types/aptos.d';
-import * as AptosTypes from './providers/types/aptos.d'
-import * as SolanaTypes from './providers/types/solana.d'
-import * as EthereumTypes from './providers/types/ethereum.d'
+import * as AptosTypes from './providers/types/aptos.d';
+import * as SolanaTypes from './providers/types/solana.d';
+import * as EthereumTypes from './providers/types/ethereum.d';
 
 export * from './providers/types/blocto.d';
 export {

--- a/packages/blocto-sdk/src/lib/is.ts
+++ b/packages/blocto-sdk/src/lib/is.ts
@@ -1,1 +1,5 @@
 export const isEmail = (value: string): boolean => /\S+@\S+\.\S+/.test(value);
+
+export const isValidTransaction = (transaction: unknown): boolean => (typeof transaction === 'object' && transaction !== null && 'from' in transaction);
+
+export const isValidTransactions = (transactions: unknown): boolean => (Array.isArray(transactions) && transactions.every(tx => isValidTransaction(tx)));

--- a/packages/blocto-sdk/src/lib/localStorage/localStorage.ts
+++ b/packages/blocto-sdk/src/lib/localStorage/localStorage.ts
@@ -17,7 +17,10 @@ const isSupported = () => {
 
 const storage = isSupported() ? window.localStorage : MemoryStorage;
 
-export const getItem = <T>(key: string, defaultValue: T | null = null): T | null => {
+export const getItem = <T>(
+  key: string,
+  defaultValue: T | null = null
+): T | null => {
   const value = storage.getItem(key);
   try {
     return (value && JSON.parse(value)) || defaultValue;

--- a/packages/blocto-sdk/src/providers/ethereum.ts
+++ b/packages/blocto-sdk/src/providers/ethereum.ts
@@ -605,7 +605,7 @@ export default class EthereumProvider
       );
     const formatParams = extractParams(payload.params as Array<any>);
     const copyPayload = { ...payload, params: formatParams };
-    
+
     return this.handleSendTransaction(copyPayload);
   }
 

--- a/packages/blocto-sdk/src/providers/ethereum.ts
+++ b/packages/blocto-sdk/src/providers/ethereum.ts
@@ -21,7 +21,7 @@ import {
   DEFAULT_APP_ID,
 } from '../constants';
 import { KEY_SESSION } from '../lib/localStorage/constants';
-import { isEmail } from '../lib/is';
+import { isEmail, isValidTransaction, isValidTransactions } from '../lib/is';
 import { EvmSupportMapping, getEvmSupport } from '../lib/getEvmSupport';
 import { ProviderSession } from './types/blocto';
 
@@ -585,6 +585,9 @@ export default class EthereumProvider
 
   async handleSendTransaction(payload: EIP1193RequestPayload): Promise<string> {
     this.#checkNetworkMatched();
+    if (!isValidTransaction(payload.params)) {
+      throw new Error('Invalid transaction in params');
+    }
     const { authorizationId } = await this.bloctoApi<{
       authorizationId: string;
     }>(`/authz`, { method: 'POST', body: JSON.stringify(payload.params) });
@@ -605,6 +608,10 @@ export default class EthereumProvider
       );
     const formatParams = extractParams(payload.params as Array<any>);
     const copyPayload = { ...payload, params: formatParams };
+
+    if (!isValidTransactions(copyPayload.params)) {
+      throw new Error('Invalid transaction in params');
+    }
 
     return this.handleSendTransaction(copyPayload);
   }

--- a/packages/blocto-sdk/src/providers/ethereum.ts
+++ b/packages/blocto-sdk/src/providers/ethereum.ts
@@ -162,6 +162,14 @@ export default class EthereumProvider
     }
   }
 
+  #extractParams(params: Array<any>): Array<any> {
+    return params.map(param => {
+      return 'params' in param ?
+        param.params[0] : // handle passing web3.eth.sendTransaction.request(...) as a parameter with params
+        param;
+    })
+  }
+
   // DEPRECATED API: see https://docs.metamask.io/guide/ethereum-provider.html#ethereum-send-deprecated
   async send(
     methodOrPayload: string | JsonRpcRequest,
@@ -583,9 +591,10 @@ export default class EthereumProvider
 
   async handleSendTransaction(payload: EIP1193RequestPayload): Promise<string> {
     this.#checkNetworkMatched();
+    const formatParams = this.#extractParams(payload.params as Array<any>);
     const { authorizationId } = await this.bloctoApi<{
       authorizationId: string;
-    }>(`/authz`, { method: 'POST', body: JSON.stringify(payload.params) });
+    }>(`/authz`, { method: 'POST', body: JSON.stringify(formatParams) });
     const authzFrame = await this.setIframe(`/authz/${authorizationId}`);
     return this.responseListener(authzFrame, 'txHash');
   }


### PR DESCRIPTION
## Summary

<!--- Provide enough context about what you’re trying to achieve. You can break it down in a few bullet-points.-->

params of EIP-1193's `method: blocto_sendBatchTransaction` is modified to accept web3.eth.sendTransaction.request(...) as a params without the need to destructure web3.eth.sendTransaction.request(...) and extract the params value in advance.


## Related Links

<!-- Asana Ticket / Mockup Design Prototype -->

**Asana**:https://app.asana.com/0/1201812548509877/1204642607252412/f

## Checklist

- [x] Pasted Asana link.
- [x] Tagged labels.

## Prerequisite/Related Pull Requests

<!-- Please paste the related PR links. -->
