### PR TITLE
fix: iframe style add insert and color-scheme

### DIFF
--- a/.changeset/spotty-emus-judge.md
+++ b/.changeset/spotty-emus-judge.md
@@ -1,0 +1,5 @@
+---
+'@blocto/sdk': patch
+---
+
+Fix insert iframe styles

--- a/packages/blocto-sdk/src/lib/frame.ts
+++ b/packages/blocto-sdk/src/lib/frame.ts
@@ -1,5 +1,5 @@
 const IFRAME_STYLE =
-  'width:100vw;height:100%;position:fixed;top:0;left:0;z-index:2147483646;border:none;';
+  'width:100vw;height:100%;position:fixed;top:0;left:0;z-index:2147483646;border:none;box-sizing:border-box;color-scheme:light;inset:0px;display:block;';
 
 export function createFrame(url: string): HTMLIFrameElement {
   const frame = document.createElement('iframe');


### PR DESCRIPTION
## Summary

Add `color-scheme:light;` to sdk iframe setup style to prevent white background.

## Related Links

<!-- Asana Ticket / Mockup Design Prototype -->

**Asana**:

## Checklist

- [ ] Pasted Asana link.
- [ ] Tagged labels.

## Prerequisite/Related Pull Requests

<!-- Please paste the related PR links. -->
