### PR TITLE
fix: validation of handleSendTransaction

### DIFF
--- a/.changeset/healthy-lizards-chew.md
+++ b/.changeset/healthy-lizards-chew.md
@@ -1,0 +1,9 @@
+---
+'@blocto/aptos-wallet-adapter-plugin': patch
+'@blocto/rainbowkit-connector': patch
+'@blocto/wagmi-connector': patch
+'@blocto/sdk': patch
+'@blocto/web3-react-connector': patch
+---
+
+Fix eth_sendTransaction function

--- a/packages/blocto-sdk/src/providers/ethereum.ts
+++ b/packages/blocto-sdk/src/providers/ethereum.ts
@@ -607,7 +607,7 @@ export default class EthereumProvider
 
   async handleSendTransaction(payload: EIP1193RequestPayload): Promise<string> {
     this.#checkNetworkMatched();
-    if (!isValidTransaction(payload.params)) {
+    if (!isValidTransaction(payload.params?.[0])) {
       throw rpcErrors.invalidParams();
     }
     const { authorizationId } = await this.bloctoApi<{


### PR DESCRIPTION
## Summary

Fix validation check of handleSendTransaction

normal 'eth_sendTransaction' should be like:
```
ethereum
      .request({
        method: 'eth_sendTransaction',
        params: [
          {
            from: '0x2f318C334780961FB129D2a6c30D0763d9a5C970',
            to: '0x2f318C334780961FB129D2a6c30D0763d9a5C970',
            value: '0x29a2241af62c0000',
          },
        ],
      })
```

## Related Links

<!-- Asana Ticket / Mockup Design Prototype -->

**Asana**:

## Checklist

- [x] Pasted Asana link.
- [x] Tagged labels.

## Prerequisite/Related Pull Requests

<!-- Please paste the related PR links. -->
