### PR TITLE
refactor: exclude rollup-plugin-visualizer in package

### DIFF
--- a/packages/blocto-sdk/package.json
+++ b/packages/blocto-sdk/package.json
@@ -10,7 +10,7 @@
   "types": "dist/blocto-sdk.d.ts",
   "type": "module",
   "files": [
-    "/dist"
+    "/dist/**/!(*.html)"
   ],
   "scripts": {
     "build": "NODE_ENV=production rollup -c",


### PR DESCRIPTION
## Summary

I found rollup-plugin-visualizer generated stats.html was accidentally inclued. Exclude in package.json
