### PR TITLE
feat: support multiple params of wallet_addEthereumChain

### DIFF
--- a/.changeset/sharp-numbers-battle.md
+++ b/.changeset/sharp-numbers-battle.md
@@ -1,0 +1,5 @@
+---
+'@blocto/sdk': patch
+---
+
+Support multiple params of wallet_addEthereumChain method

--- a/packages/blocto-sdk/src/providers/ethereum.ts
+++ b/packages/blocto-sdk/src/providers/ethereum.ts
@@ -361,16 +361,7 @@ export default class EthereumProvider
           result = await this.handleSendUserOperation(payload);
           break;
         case 'wallet_addEthereumChain':
-          if (
-            !payload?.params?.[0]?.chainId ||
-            !payload?.params?.[0]?.rpcUrls.length
-          ) {
-            throw ethErrors.rpc.invalidParams();
-          }
-          this.#addToSwitchable({
-            chainId: `${parseChainId(payload?.params?.[0]?.chainId)}`,
-            rpcUrls: payload?.params?.[0].rpcUrls,
-          });
+          await this.loadSwitchableNetwork(payload?.params || []);
           result = null;
           break;
         case 'wallet_switchEthereumChain':
@@ -704,12 +695,13 @@ export default class EthereumProvider
   ): Promise<null> {
     // setup switchable list if user set networkList
     if (networkList?.length) {
-      const listToAdd = networkList.map(({ chainId: chain_id, rpcUrls }) => {
+      const listToAdd = networkList.map(({ chainId, rpcUrls }) => {
         invariant(rpcUrls, 'rpcUrls is required for networksList');
+        if (!chainId) throw ethErrors.rpc.invalidParams('Empty chainId');
         if (!rpcUrls?.length)
           throw ethErrors.rpc.invalidParams('Empty rpcUrls');
         return this.#addToSwitchable({
-          chainId: `${parseChainId(chain_id)}`,
+          chainId: `${parseChainId(chainId)}`,
           rpcUrls,
         });
       });


### PR DESCRIPTION
## Summary

Support more than one param of wallet_addEthereumChain.

```
bloctoSDK.ethereum
  .request({
    method: "wallet_addEthereumChain", // add chain first
    params: [
      {
        chainId: 97, // BSC testnet
        rpcUrls: ["https://..."],
      },
      {
        chainId: 80001, // Polygon testnet
        rpcUrls: ["https://..."],
      },
    ],
  })
```

## Related Links

<!-- Asana Ticket / Mockup Design Prototype -->

**Asana**: https://app.asana.com/0/1201812548509877/1204859140280170/f

## Checklist

- [ ] Pasted Asana link.
- [ ] Tagged labels.

## Prerequisite/Related Pull Requests

<!-- Please paste the related PR links. -->
