### PR TITLE
Fix/evm disconnect event

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -6,13 +6,14 @@
     "@blocto/rainbowkit-connector": "0.1.3-beta.0",
     "@blocto/wagmi-connector": "0.2.4-beta.0",
     "@blocto/web3-react-connector": "0.4.4-beta.0",
-    "@blocto/sdk": "0.5.0-beta.5",
+    "@blocto/sdk": "0.5.0-beta.6",
     "eslint-config-custom": "0.0.0",
     "tsconfig": "0.0.0"
   },
   "changesets": [
     "dull-pigs-double",
     "early-dots-pretend",
+    "eleven-lobsters-buy",
     "famous-toes-burn",
     "fluffy-cougars-deny",
     "good-flowers-fetch",

--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -6,7 +6,7 @@
     "@blocto/rainbowkit-connector": "0.1.3-beta.0",
     "@blocto/wagmi-connector": "0.2.4-beta.0",
     "@blocto/web3-react-connector": "0.4.4-beta.0",
-    "@blocto/sdk": "0.5.0-beta.6",
+    "@blocto/sdk": "0.5.0-beta.7",
     "eslint-config-custom": "0.0.0",
     "tsconfig": "0.0.0"
   },
@@ -23,6 +23,7 @@
     "hot-turkeys-whisper",
     "perfect-emus-change",
     "pretty-toys-think",
+    "rare-dragons-hunt",
     "sharp-numbers-battle",
     "short-mails-enjoy",
     "sour-cups-sip",

--- a/.changeset/rare-dragons-hunt.md
+++ b/.changeset/rare-dragons-hunt.md
@@ -1,0 +1,5 @@
+---
+'@blocto/sdk': patch
+---
+
+fix: ethereum provider should emits ProviderRpcError when disconnect

--- a/packages/blocto-sdk/CHANGELOG.md
+++ b/packages/blocto-sdk/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @blocto/sdk
 
+## 0.5.0-beta.8
+
+### Patch Changes
+
+- c3485b6: fix: ethereum provider should emits ProviderRpcError when disconnect
+
 ## 0.5.0-beta.7
 
 ### Patch Changes

--- a/packages/blocto-sdk/CHANGELOG.md
+++ b/packages/blocto-sdk/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @blocto/sdk
 
+## 0.5.0-beta.7
+
+### Patch Changes
+
+- a83376b: Fix session id not updated when set storage
+
 ## 0.5.0-beta.6
 
 ### Patch Changes

--- a/packages/blocto-sdk/package.json
+++ b/packages/blocto-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blocto/sdk",
-  "version": "0.5.0-beta.7",
+  "version": "0.5.0-beta.8",
   "repository": "git@github.com:portto/blocto-sdk.git",
   "author": "Chiaki.C",
   "license": "MIT",

--- a/packages/blocto-sdk/package.json
+++ b/packages/blocto-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blocto/sdk",
-  "version": "0.5.0-beta.6",
+  "version": "0.5.0-beta.7",
   "repository": "git@github.com:portto/blocto-sdk.git",
   "author": "Chiaki.C",
   "license": "MIT",

--- a/packages/blocto-sdk/src/providers/ethereum.ts
+++ b/packages/blocto-sdk/src/providers/ethereum.ts
@@ -424,7 +424,9 @@ export default class EthereumProvider
     })
       .then((response) =>
         responseSessionGuard<T>(response, sessionKey, () => {
-          this.eventListeners?.disconnect.forEach((listener) => listener(null));
+          this.eventListeners?.disconnect.forEach((listener) =>
+            listener(ethErrors.provider.disconnected())
+          );
         })
       )
       .catch((e) => {
@@ -697,7 +699,9 @@ export default class EthereumProvider
     }
     const { sessionKey, blockchainName } = await this.#getBloctoProperties();
     removeChainAddress(sessionKey, blockchainName);
-    this.eventListeners?.disconnect.forEach((listener) => listener(null));
+    this.eventListeners?.disconnect.forEach((listener) =>
+      listener(ethErrors.provider.disconnected())
+    );
   }
 
   async loadSwitchableNetwork(


### PR DESCRIPTION
## Summary

Fix evm provider not emit error in disconnect event.

>  ### disconnect
>  The Provider emits disconnect when it becomes disconnected from all chains.
>  `Provider.on('disconnect', listener: (error: ProviderRpcError) => void): Provider;`
> This event emits a [ProviderRpcError](https://eips.ethereum.org/EIPS/eip-1193#errors). The error code follows the table of [CloseEvent status codes](https://developer.mozilla.org/en-US/docs/Web/API/CloseEvent#Status_codes).

See: https://eips.ethereum.org/EIPS/eip-1193#Events

## Related Links

<!-- Asana Ticket / Mockup Design Prototype -->

**Asana**:

## Checklist

- [ ] Pasted Asana link.
- [ ] Tagged labels.

## Prerequisite/Related Pull Requests

<!-- Please paste the related PR links. -->
